### PR TITLE
Added "Add to mine" Button

### DIFF
--- a/client/src/dashboard/QueryLogs.js
+++ b/client/src/dashboard/QueryLogs.js
@@ -57,7 +57,7 @@ export default function QueryLogs() {
   // show a query's suggestion rewriting path
   const showQuerySuggestionRewritingPath = (query) => {
     console.log(query);
-    NiceModal.show(QuerySuggestionRewritingPath, {queryId: query.id, user: user});
+    NiceModal.show(QuerySuggestionRewritingPath, {user: user, queryId: query.id});
   };
 
   return (

--- a/client/src/dashboard/QueryLogs.js
+++ b/client/src/dashboard/QueryLogs.js
@@ -57,7 +57,7 @@ export default function QueryLogs() {
   // show a query's suggestion rewriting path
   const showQuerySuggestionRewritingPath = (query) => {
     console.log(query);
-    NiceModal.show(QuerySuggestionRewritingPath, {queryId: query.id});
+    NiceModal.show(QuerySuggestionRewritingPath, {queryId: query.id, user: user});
   };
 
   return (

--- a/client/src/dashboard/QuerySuggestionRewritingPath.js
+++ b/client/src/dashboard/QuerySuggestionRewritingPath.js
@@ -16,8 +16,8 @@ import defaultSuggestionRewritingPathData from '../mock-api/suggestionRewritingP
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import {userContext} from "../userContext";
-import RewritingRuleModal from "./RewritingRuleModal";
-import listRules from "./RewritingRuleModal";
+import RewritingRuleModal, { listRules } from "./RewritingRuleModal";
+
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',

--- a/client/src/dashboard/QuerySuggestionRewritingPath.js
+++ b/client/src/dashboard/QuerySuggestionRewritingPath.js
@@ -16,6 +16,8 @@ import defaultSuggestionRewritingPathData from '../mock-api/suggestionRewritingP
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import { vs } from 'react-syntax-highlighter/dist/esm/styles/hljs';
 import {userContext} from "../userContext";
+import RewritingRuleModal from "./RewritingRuleModal";
+import listRules from "./RewritingRuleModal";
 
 const Item = styled(Paper)(({ theme }) => ({
   backgroundColor: theme.palette.mode === 'dark' ? '#1A2027' : '#fff',
@@ -25,7 +27,7 @@ const Item = styled(Paper)(({ theme }) => ({
   color: theme.palette.text.primary,
 }));
 
-const QuerySuggestionRewritingPath = NiceModal.create(({ queryId }) => {
+const QuerySuggestionRewritingPath = NiceModal.create(({ queryId, user }) => {
   const modal = useModal();
   // Set up a state for rewritingPath
   const [suggestionRewritingPath, setSuggestionRewritingPath] = React.useState({rewritings:[]});
@@ -55,6 +57,16 @@ const QuerySuggestionRewritingPath = NiceModal.create(({ queryId }) => {
   // call getSuggestionRewritePath() only once after initial rendering
   React.useEffect(() => {getSuggestionRewritingPath(queryId)}, []);
 
+  // handle click on add rewriting rule button AND edit rewriting rule button
+  const AddOrEditRewritingRule = (q0, q1) => {
+    var query = [JSON.stringify(q0), q1];
+    NiceModal.show(RewritingRuleModal, {user_id: user.id, query: query})
+    .then((res) => {
+      console.log(res);
+      listRules();
+    });
+  };
+
   return (
     <Dialog
       open={modal.visible}
@@ -79,7 +91,7 @@ const QuerySuggestionRewritingPath = NiceModal.create(({ queryId }) => {
                     <Stack direction="row" spacing={2} >
                       <Item>{rewriting.rule}</Item>
                       <Item>{rewriting.rule_user_email}</Item>
-                      <Button variant="outlined">Add to mine</Button>
+                      <Button variant="outlined" onClick={() => AddOrEditRewritingRule(suggestionRewritingPath.original_sql, rewriting.rewritten_sql)} >Add to mine</Button>
                     </Stack>
                   </Item>
                   <Item>

--- a/client/src/dashboard/QuerySuggestionRewritingPath.js
+++ b/client/src/dashboard/QuerySuggestionRewritingPath.js
@@ -27,7 +27,7 @@ const Item = styled(Paper)(({ theme }) => ({
   color: theme.palette.text.primary,
 }));
 
-const QuerySuggestionRewritingPath = NiceModal.create(({ queryId, user }) => {
+const QuerySuggestionRewritingPath = NiceModal.create(({ user, queryId }) => {
   const modal = useModal();
   // Set up a state for rewritingPath
   const [suggestionRewritingPath, setSuggestionRewritingPath] = React.useState({rewritings:[]});

--- a/client/src/dashboard/RewritingRuleModal.js
+++ b/client/src/dashboard/RewritingRuleModal.js
@@ -17,18 +17,19 @@ import defaultRulesData from '../mock-api/listRules';
 import { FormLabel } from '@mui/material';
 import RuleGraph from './RuleGraph';
 
-const RewritingRuleModal = NiceModal.create(({user_id, rule=null}) => {
+const RewritingRuleModal = NiceModal.create(({user_id, rule=null, query=null}) => {
   const modal = useModal();
   // Set up states for a rewriting rule
   const isNewRule = !rule;
+  const hasQuery = !!query;
   const [name, setName] = React.useState(isNewRule ? "" : rule.name);
   const [pattern, setPattern] = React.useState(isNewRule ? "" : rule.pattern);
   const [constraints, setConstraints] = React.useState(isNewRule ? "" : rule.constraints);
   const [rewrite, setRewrite] = React.useState(isNewRule ? "" : rule.rewrite);
   const [actions, setActions] = React.useState(isNewRule ? "" : rule.actions);
   // Set up states for an example rewriting pair
-  const [q0, setQ0] = React.useState("");
-  const [q1, setQ1] = React.useState("");
+  const [q0, setQ0] = React.useState(hasQuery ? query[0] : "");
+  const [q1, setQ1] = React.useState(hasQuery ? query[1] : "");
 
   const onNameChange = (event) => {
     setName(event.target.value);


### PR DESCRIPTION
## Description
This PR implements the functionality for the `Add to mine` button, allowing users to add suggested rules and modify them.
By pressing the `Add to mine` button, users can edit the suggested query and save it as their own Rewriting Rule. 

<img width="1680" alt="Screenshot 2023-08-21 at 4 35 48 PM" src="https://github.com/ISG-ICS/QueryBooster/assets/75426413/141873c7-85d3-436d-931c-e6120d7eb3bc">

## Changes Made
- Added Add to mine button functionalities inside `QuerySuggestionRewritingPath.js`
- Modified `RewritingRuleModal.js` to allow queries to be shown in the modal.
- `QueryLogs.js`: added attribute `user` for `NiceModal` to allow the query to be saved given the user.id