### PR TITLE
Fix/flask route404

### DIFF
--- a/client/src/dashboard/Dashboard.js
+++ b/client/src/dashboard/Dashboard.js
@@ -96,7 +96,7 @@ const mdTheme = createTheme();
 
 function DashboardContent() {
   const [user, setUser] = React.useState(() => {
-    return JSON.parse(localStorage.getItem('userInfo')) || {}
+    return JSON.parse(sessionStorage.getItem('userInfo')) || {}
   });
   const [open, setOpen] = React.useState(true);
   const toggleDrawer = () => {
@@ -138,13 +138,13 @@ function DashboardContent() {
 
   const logout = () => {
     googleLogout();
-    localStorage.removeItem('userInfo');
+    sessionStorage.removeItem('userInfo');
     setUser({});
     forceUpdate();
 };
 
   React.useEffect(() => {
-    localStorage.setItem('userInfo', JSON.stringify(user));
+    sessionStorage.setItem('userInfo', JSON.stringify(user));
   }, [user]);
 
   return (

--- a/client/src/dashboard/Dashboard.js
+++ b/client/src/dashboard/Dashboard.js
@@ -22,7 +22,7 @@ import MenuIcon from '@mui/icons-material/Menu';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import NotificationsIcon from '@mui/icons-material/Notifications';
 import { mainListItems, secondaryListItems } from './listItems';
-import { Routes, Route, UNSAFE_RouteContext } from "react-router-dom";
+import { Routes, Route } from "react-router-dom";
 import RewritingRules from './RewritingRules';
 import RuleFormulator from './RuleFormulator';
 import QueryLogs from './QueryLogs';
@@ -95,7 +95,9 @@ const Drawer = styled(MuiDrawer, { shouldForwardProp: (prop) => prop !== 'open' 
 const mdTheme = createTheme();
 
 function DashboardContent() {
-  const [user, setUser] = React.useState({});
+  const [user, setUser] = React.useState(() => {
+    return JSON.parse(localStorage.getItem('userInfo')) || {}
+  });
   const [open, setOpen] = React.useState(true);
   const toggleDrawer = () => {
     setOpen(!open);
@@ -136,11 +138,14 @@ function DashboardContent() {
 
   const logout = () => {
     googleLogout();
+    localStorage.removeItem('userInfo');
     setUser({});
     forceUpdate();
 };
 
-  React.useEffect(() => {}, []);
+  React.useEffect(() => {
+    localStorage.setItem('userInfo', JSON.stringify(user));
+  }, [user]);
 
   return (
     <userContext.Provider value={user}>
@@ -242,7 +247,6 @@ function DashboardContent() {
                 <Grid item xs={12}>
                   <Paper sx={{ p: 2, display: 'flex', flexDirection: 'column' }}>
                     <Routes>
-                      {/* <RewritingRules /> */}
                       <Route exact path="/" element={<RewritingRules />} />
                       <Route path="/formulator" element={<RuleFormulator />} />
                       <Route path="/jdbc" element={<JDBCDrivers />} />

--- a/server/server.py
+++ b/server/server.py
@@ -451,3 +451,8 @@ def background_suggest_rewritings(guid):
     log_text += "\n--------------------------------------------------"
 
     return None
+
+#fix 404 issue: set up server side routing
+@app.errorhandler(404)   
+def not_found(e):  
+    return send_from_directory('./static/', 'index.html')


### PR DESCRIPTION
## Description
This PR has resolved the 404 error that occurred when clicking the refresh button in a web browser. After this fix, the website will reload the entire page as expected, and the user's account will remain logged in.

![404](https://github.com/ISG-ICS/QueryBooster/assets/116992300/987c9cf9-98a1-4b1d-835f-3cb7c5bc21ce)
<p align="center">
Refresh after the fix
</p>

## Changes Made
- Added errorhandler in server.py to handle 404 errors and re-route to React index file to handle the page reload.
- Utilized sessionStorage to keep user logged in upon refresh.