### PR TITLE
Feature/generate rules graph

### DIFF
--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -8,8 +8,6 @@ import mo_sql_parsing as mosql
 import numbers
 import re
 import time
-from collections import deque 
-from typing import Dict, Tuple
 
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -206,8 +206,8 @@ def recommend_rules():
 
         database = request_data.get('database')
         examples = request_data.get('examples')
-        root_rules_json = RuleGenerator.generate_rules_graph(examples)
-        recommend_rules_json = RuleGenerator.recommend_rules(root_rules_json, len(examples))
+
+        recommend_rules_json = RuleGenerator.recommend_simple_rules(examples)
 
         # Patch pattern and rewrite in recommended rules
         for rule in recommend_rules_json:


### PR DESCRIPTION
# Description
- Implemented `recomment_simple_rules` and `generate_minimal_rule` to recommend a simplified rules set that covers all query pairs provided as input. The functions generate a set of rules that cover all examples.
- `recommend_simple_rules()` function iterates through each example in the input. For each example, it checks if it's not already covered and generates a minimal rule using the generate_minimal_rule function.
- `generate_minimal_rule()` function generates a minimal rule given two SQL queries (q0 and q1) and a set of examples. It starts with a seed rule and iteratively generates child rules by applying transformations. It tracks covered examples and avoids generating redundant rules using a visited dictionary.