### PR TITLE
Remove Special Cases

### DIFF
--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -849,29 +849,8 @@ class RuleGenerator:
         superSet = []
         for patternValue, patternNames in patternSet.items():
             rewriteNames = rewriteSet.get(patternValue, [])
-            # special case 1: 
-            #   if the patternTable ONLY has {'value': 'employee', 'name': 'employee'}
-            #   and the rewriteTable ONLY has {'value': 'employee', 'name': 'e1'},
-            #   we replace 'employee' with 'e1' as table alias  
-            #   the purpose is for the next step when we replace tables with variables, 
-            #   we should be able to know the patternTable and rewriteTable should be replaced with the same variable.  
-            #   This logic will much simpler once we complete refactoring the code to introduce an internal tree structure  
-            #   to represent the AST instead of the current JSON structure, where can easily determine if two tables  
-            #   are the same table with different alias names.
-            #
-            if len(patternNames) == 1 and len(rewriteNames) == 1 and patternNames[0] == patternValue:
-                patternNames = rewriteNames
-            # special case 2:
-            #   if the patternTable ONLY has {'value': 'employee', 'name': 'employee'}
-            #   and the rewriteTable has multiple alias to the same table, e.g., {'value': 'employee', 'name': 'e1'}, {'value': 'employee', 'name': 'e2'}
-            #   we directly append 'e1' and 'e2' as table alias to the superSet as IN MOST CASES patternTable's name should be included in rewriteTable's alias name
-            #   the purpose is for the next step when we replace tables with variables
-            #
-            elif len(patternNames) == 1 and len(rewriteNames) != 0 and patternNames[0] == patternValue:
-                superSet += [{'value': patternValue, 'name': name} for name in rewriteNames]
-                continue
-            else:
-                patternNames += [name for name in rewriteNames if name not in patternNames]
+            patternNames += [name for name in rewriteNames if name not in patternNames]
+            
             superSet += [{'value': patternValue, 'name': name} for name in patternNames]
 
         patternTables = superSet

--- a/tests/test_rule_generator.py
+++ b/tests/test_rule_generator.py
@@ -2144,10 +2144,10 @@ def test_generate_general_rule_15():
 def test_generate_general_rule_16():
     q0 = """SELECT historicoestatusrequisicion_id, requisicion_id, estatusrequisicion_id, 
             comentario, fecha_estatus, usuario_id
-            FROM historicoestatusrequisicion
+            FROM historicoestatusrequisicion hist1
             WHERE requisicion_id IN
             (
-            SELECT requisicion_id FROM historicoestatusrequisicion
+            SELECT requisicion_id FROM historicoestatusrequisicion hist2
             WHERE usuario_id = 27 AND estatusrequisicion_id = 1
             )
             ORDER BY requisicion_id, estatusrequisicion_id"""
@@ -2161,8 +2161,8 @@ def test_generate_general_rule_16():
     assert type(rule) is dict
 
     q0_rule, q1_rule = unify_variable_names(rule['pattern'], rule['rewrite'])
-    assert q0_rule== "SELECT <x1>, <x2>, <x3>, <x4>, <x5>, <x6> FROM <x7> WHERE <x2> IN (SELECT <x2> FROM <x7> WHERE <x6> = <x8> AND <x3> = <x9>) ORDER BY <x2>, <x3>"
-    assert q1_rule == "SELECT <x7>.<x1>, <x7>.<x2>, <x7>.<x3>, <x7>.<x4>, <x7>.<x5>, <x7>.<x6> FROM <x7> JOIN <x10> ON <x10>.<x2> = <x7>.<x2> WHERE <x10>.<x6> = <x8> AND <x10>.<x3> = <x9> ORDER BY <x7>.<x2>, <x7>.<x3>"
+    assert q0_rule== "SELECT <x1>, <x2>, <x3>, <x4>, <x5>, <x6> FROM <x7> WHERE <x2> IN (SELECT <x2> FROM <x8> WHERE <x6> = <x9> AND <x3> = <x10>) ORDER BY <x2>, <x3>"
+    assert q1_rule == "SELECT <x7>.<x1>, <x7>.<x2>, <x7>.<x3>, <x7>.<x4>, <x7>.<x5>, <x7>.<x6> FROM <x7> JOIN <x8> ON <x8>.<x2> = <x7>.<x2> WHERE <x8>.<x6> = <x9> AND <x8>.<x3> = <x10> ORDER BY <x7>.<x2>, <x7>.<x3>"
 
 
 def test_generate_general_rule_17():
@@ -2172,10 +2172,10 @@ def test_generate_general_rule_17():
             from spoleczniak_subskrypcje
             where postac_id = 376476
             )"""
-    q1 = """select o.wpis_id 
-            from spoleczniak_oznaczone o
-            inner join spoleczniak_subskrypcje s on s.tag_id = o.etykieta_id
-            where s.postac_id = 376476"""
+    q1 = """select spoleczniak_oznaczone.wpis_id 
+            from spoleczniak_oznaczone
+            inner join spoleczniak_subskrypcje on spoleczniak_subskrypcje.tag_id = spoleczniak_oznaczone.etykieta_id
+            where spoleczniak_subskrypcje.postac_id = 376476"""
 
     rule = RuleGenerator.generate_general_rule(q0, q1)
     assert type(rule) is dict

--- a/tests/test_rule_generator.py
+++ b/tests/test_rule_generator.py
@@ -2162,7 +2162,7 @@ def test_generate_general_rule_16():
 
     q0_rule, q1_rule = unify_variable_names(rule['pattern'], rule['rewrite'])
     assert q0_rule== "SELECT <x1>, <x2>, <x3>, <x4>, <x5>, <x6> FROM <x7> WHERE <x2> IN (SELECT <x2> FROM <x7> WHERE <x6> = <x8> AND <x3> = <x9>) ORDER BY <x2>, <x3>"
-    assert q1_rule == "SELECT <x10>.<x1>, <x10>.<x2>, <x10>.<x3>, <x10>.<x4>, <x10>.<x5>, <x10>.<x6> FROM <x10> JOIN <x11> ON <x11>.<x2> = <x10>.<x2> WHERE <x11>.<x6> = <x8> AND <x11>.<x3> = <x9> ORDER BY <x10>.<x2>, <x10>.<x3>"
+    assert q1_rule == "SELECT <x7>.<x1>, <x7>.<x2>, <x7>.<x3>, <x7>.<x4>, <x7>.<x5>, <x7>.<x6> FROM <x7> JOIN <x10> ON <x10>.<x2> = <x7>.<x2> WHERE <x10>.<x6> = <x8> AND <x10>.<x3> = <x9> ORDER BY <x7>.<x2>, <x7>.<x3>"
 
 
 def test_generate_general_rule_17():


### PR DESCRIPTION
## Changes Made
- Remove two special cases in the `tables` method.
- Modify `test_generate_general_rule_16` and `test_generate_general_rule_17` to ensure that the test queries adhere to the following rules:
     - If a table appears multiple times in both the pattern and rewrite queries, it must have the same alias on both sides to be considered the same table variable.
     - If a table appears only once in both the pattern and rewrite queries without an alias, it is also considered the same table variable.
    - In all other cases, tables are considered different variables, even if they originate from the same table.
## Testing
- Passed all existing test cases defined under `test` 