### PR TITLE
[Improvement] Partial Matching

### DIFF
--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -379,10 +379,10 @@ class QueryRewriter:
         if memo_additional_key_value_pairs != {}:
             memo[memo_key] = memo_additional_key_value_pairs
         # Check child nodes for possible partial matches, and add in current logical operator's memo
-        #   e.g., query_node = {"and": [{"key1": [...]}, {"key2": [...]}]}
-        #         rule_node = {"key1": [...]}
-        #   After matching, we need to add the remaining {"key2": [...]} into the memo, so the memo becomes:
-        #                memo = {"and": [{"key2": [...]}], ...}
+        #   e.g., query_node = {"and": [{"key1": [...]}, {"key2": [...]}, {"key3": [...]}]}
+        #         rule_node = {"and": [{"key1": [...]}, {"key2": [...]}]}
+        #   After matching, we need to add the remaining {"key3": [...]} into the memo, so the memo becomes:
+        #                memo = {"and": [{"key3": [...]}], ...}
         elif "partial_match_list" in memo.keys():
             memo[memo_key] = memo["partial_match_list"]
             del memo["partial_match_list"]

--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -586,6 +586,10 @@ class QueryRewriter:
         if query is memo['rule']:
             # replace query by rule's rewrite
             # 
+            if QueryRewriter.is_dict(query):
+                if len(query) == 1 and (op := next(iter(query))) in memo.keys():
+                    memo["full_rule"] = [op, memo[op]]
+
             query = copy.deepcopy(rule['rewrite_json'])
                 
         # 2nd case, find rewrite's Var or VarList
@@ -610,6 +614,10 @@ class QueryRewriter:
 
             for key, child in query.items():
                 query[key] = QueryRewriter.replace(child, rule, memo)
+            
+            if 'full_rule' in memo.keys():
+                query = {memo['full_rule'][0]: [query, memo['full_rule'][1]]}
+                del memo['full_rule']
 
         if QueryRewriter.is_list(query):
             ans = []

--- a/data/rules.py
+++ b/data/rules.py
@@ -432,7 +432,7 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
         'rewrite': '<x> IN (<<y>>, <<z>>)',
         'actions': '',
         'database': 'mysql'
-    } ,
+    },
     {
       "id": 2261,
       'key': 'multiple_merge_in',

--- a/data/rules.py
+++ b/data/rules.py
@@ -405,8 +405,8 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
     },
     {
         'id': 2258,
-        'key': 'multiple_equality_comparisons_with_or_to_same_element',
-        'name': 'multiple equality comparisons with or to same element',
+        'key': 'combine_or_to_in',
+        'name': 'combine multiple or to in',
         'pattern': '<x> = <y> OR <x> = <z>',
         'constraints': '',
         'rewrite': '<x> IN (<y>, <z>)',
@@ -415,8 +415,8 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
     },
     {
         'id': 2259,
-        'key': 'merge_or_comparison_with_in_condition',
-        'name': 'merge or comparison with in condition',
+        'key': 'merge_or_to_in',
+        'name': 'merge or to in',
         'pattern': '<x> IN (<<y>>) OR <x> = <z>',
         'constraints': '',
         'rewrite': '<x> IN (<<y>>, <z>)',

--- a/data/rules.py
+++ b/data/rules.py
@@ -403,6 +403,56 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
         'actions': '',
         'database': 'postgresql'
     },
+    {
+        'id': 2258,
+        'key': 'multiple_equality_comparisons_with_or_to_same_element',
+        'name': 'multiple equality comparisons with or to same element',
+        'pattern': '<x> = <y> OR <x> = <z>',
+        'constraints': '',
+        'rewrite': '<x> IN (<y>, <z>)',
+        'actions': '',
+        'database': 'mysql'
+    },
+    {
+        'id': 2259,
+        'key': 'merge_or_comparison_with_in_condition',
+        'name': 'merge or comparison with in condition',
+        'pattern': '<x> IN (<<y>>) OR <x> = <z>',
+        'constraints': '',
+        'rewrite': '<x> IN (<<y>>, <z>)',
+        'actions': '',
+        'database': 'mysql'
+    },
+    {
+        'id': 2260,
+        'key': 'merge_in_statements',
+        'name': 'merge statements with in condition',
+        'pattern': '<x> IN <<y>> OR <x> IN <<z>>',
+        'constraints': '',
+        'rewrite': '<x> IN (<<y>>, <<z>>)',
+        'actions': '',
+        'database': 'mysql'
+    } ,
+    {
+      "id": 2261,
+      'key': 'multiple_merge_in',
+      'name': 'multiple merge in',
+      "pattern": "<x> IN (<<y>>) OR <x> IN (<<z>>)",
+      'constraints': '',
+      "rewrite": "<x> IN (<<y>>, <<z>>)",
+      'actions': '',
+      'database': 'mysql'
+    },
+    {
+      "id": 2262,
+      'key': 'partial_subquery_to_join',
+      'name': 'partial subquery to join',
+      "pattern": "SELECT <x17>, <x16>, <x15>, <x14> FROM <x1> WHERE <x8> IN (SELECT <x4> FROM <x2> WHERE <<y2>>)",
+      'constraints': '',
+      "rewrite": "SELECT DISTINCT <x17>, <x16>, <x15>, <x14> FROM <x1>, <x2> WHERE <x1>.<x8> = <x2>.<x4> AND <<y2>>",
+      'actions': '',
+      'database': 'mysql'
+    }
 ]
 
 # fetch one rule by key (json attributes are in json)

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1079,6 +1079,125 @@ def test_rewrite_stackoverflow_1():
     assert format(parse(q1)) == format(parse(_q1))
 
 
+def test_partial_matching_base_case1():
+    q0 = '''
+        SELECT *
+        FROM A a
+        LEFT JOIN B b ON a.id = b.cid
+        WHERE
+        b.cl1 = 's1' OR b.cl1 ='s2'
+        '''
+    q1 = '''
+        SELECT *
+        FROM A a
+        LEFT JOIN B b ON a.id = b.cid
+        WHERE
+        b.cl1 IN ('s1', 's2')
+        '''
+    rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
+# TODO: need to rewrite the query as  b.cl1 IN ('s3', 's1', 's2') instead of double parenthesis
+# def test_partial_matching_base_case2():
+#     q0 = '''
+#         SELECT *
+#         FROM b
+#         WHERE
+#         b.cl1 IN ('s1', 's2') OR b.cl1 ='s3'
+#         '''
+#     q1 = '''
+#         SELECT *
+#         FROM b
+#         WHERE
+#         b.cl1 IN ('s3', ('s1', 's2'))
+#         '''
+#     rule_keys = ['merge_or_comparison_with_in_condition']
+#     rules = [get_rule(k) for k in rule_keys]
+#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+#     assert format(parse(q1)) == format(parse(_q1))
+
+# def test_partial_matching_base_case3():
+#     q0 = '''
+#         SELECT * FROM t WHERE t.a IN ((1, 2),3) OR t.a = 4
+#         '''
+#     q1 = '''
+#         SELECT * FROM t WHERE t.a IN (((1, 2), 3), 4)
+#         '''
+#     rule_keys = ['multiple_merge_in']
+#     rules = [get_rule(k) for k in rule_keys]
+#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+
+#     assert format(parse(q1)) == format(parse(_q1))
+
+# TODO: only need to do replacement
+def test_partial_matching0(): 
+    q0 = '''
+        SELECT *
+        FROM A a
+        LEFT JOIN B b ON a.id = b.cid
+        WHERE
+        b.cl1 = 's1' OR b.cl1 = 's2' OR b.cl1 = 's3'
+        '''
+    q1 = '''
+        SELECT *
+        FROM A a
+        LEFT JOIN B b ON a.id = b.cid
+        WHERE
+        b.cl1 IN ('s1', 's2') OR b.cl1 = 's3'
+        '''
+    rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
+# def test_partial_matching_1(): #test for basic matching
+#     q0 = '''
+#         SELECT *
+#         FROM A a
+#         LEFT JOIN B b ON a.id = b.cid
+#         WHERE
+#         b.cl1 = 's1' OR b.cl1 ='s2' OR b.cl1 ='s3'
+#         '''
+#     q1 = '''
+#         SELECT *
+#         FROM A a
+#         LEFT JOIN B b ON a.id = b.cid
+#         WHERE
+#         b.cl1 IN ('s1', 's2', 's3')
+#         '''
+#     rule_keys = ['merge_or_comparison_with_in_condition', 'multiple_equality_comparisons_with_or_to_same_element']
+#     rules = [get_rule(k) for k in rule_keys]
+#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+#     assert format(parse(q1)) == format(parse(_q1))
+
+
+def test_partial_matching4():
+    q0 = '''
+        select empno, firstname, lastname, phoneno
+        from employee
+        where workdept in
+            (select deptno
+                from department
+                where deptname = 'OPERATIONS')
+        and firstname like 'B%'
+        '''
+    q1 = '''
+        select distinct empno, firstname, lastname, phoneno
+        from employee, department
+        where employee.workdept = department.deptno
+        and deptname = 'OPERATIONS'
+        and firstname like 'B%'
+        '''
+    rule_keys = ['partial_subquery_to_join']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
 # TODO - TBI
 # 
 def test_rewrite_postgresql():

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1146,7 +1146,7 @@ def test_partial_matching0():
         FROM A a
         LEFT JOIN B b ON a.id = b.cid
         WHERE
-        b.cl1 IN ('s1', 's2') OR b.cl1 = 's3'
+        b.cl1 IN ('s1', 's2') OR b.cl1 = 's3 '
         '''
     rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
     rules = [get_rule(k) for k in rule_keys]

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -529,7 +529,6 @@ def test_rewrite_rule_replace_strpos_lower():
 
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
-    print(format(parse(_q1)))
     assert format(parse(q1)) == format(parse(_q1))
 
 
@@ -1102,38 +1101,25 @@ def test_partial_matching_base_case1():
 
 
 # TODO: need to rewrite the query as  b.cl1 IN ('s3', 's1', 's2') instead of double parenthesis
-# def test_partial_matching_base_case2():
-#     q0 = '''
-#         SELECT *
-#         FROM b
-#         WHERE
-#         b.cl1 IN ('s1', 's2') OR b.cl1 ='s3'
-#         '''
-#     q1 = '''
-#         SELECT *
-#         FROM b
-#         WHERE
-#         b.cl1 IN ('s3', ('s1', 's2'))
-#         '''
-#     rule_keys = ['merge_or_comparison_with_in_condition']
-#     rules = [get_rule(k) for k in rule_keys]
-#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
-#     assert format(parse(q1)) == format(parse(_q1))
+def test_partial_matching_base_case2():
+    q0 = '''
+        SELECT *
+        FROM b
+        WHERE
+        b.cl1 IN ('s1', 's2') OR b.cl1 ='s3'
+        '''
+    q1 = '''
+        SELECT *
+        FROM b
+        WHERE
+        b.cl1 IN ('s3', ('s1', 's2'))
+        '''
+    rule_keys = ['merge_or_comparison_with_in_condition']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
 
-# def test_partial_matching_base_case3():
-#     q0 = '''
-#         SELECT * FROM t WHERE t.a IN ((1, 2),3) OR t.a = 4
-#         '''
-#     q1 = '''
-#         SELECT * FROM t WHERE t.a IN (((1, 2), 3), 4)
-#         '''
-#     rule_keys = ['multiple_merge_in']
-#     rules = [get_rule(k) for k in rule_keys]
-#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
 
-#     assert format(parse(q1)) == format(parse(_q1))
-
-# TODO: only need to do replacement
 def test_partial_matching0(): 
     q0 = '''
         SELECT *
@@ -1153,27 +1139,6 @@ def test_partial_matching0():
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
-
-
-# def test_partial_matching_1(): #test for basic matching
-#     q0 = '''
-#         SELECT *
-#         FROM A a
-#         LEFT JOIN B b ON a.id = b.cid
-#         WHERE
-#         b.cl1 = 's1' OR b.cl1 ='s2' OR b.cl1 ='s3'
-#         '''
-#     q1 = '''
-#         SELECT *
-#         FROM A a
-#         LEFT JOIN B b ON a.id = b.cid
-#         WHERE
-#         b.cl1 IN ('s1', 's2', 's3')
-#         '''
-#     rule_keys = ['merge_or_comparison_with_in_condition', 'multiple_equality_comparisons_with_or_to_same_element']
-#     rules = [get_rule(k) for k in rule_keys]
-#     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
-#     assert format(parse(q1)) == format(parse(_q1))
 
 
 def test_partial_matching4():

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -529,6 +529,7 @@ def test_rewrite_rule_replace_strpos_lower():
 
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    print(format(parse(_q1)))
     assert format(parse(q1)) == format(parse(_q1))
 
 
@@ -1146,7 +1147,7 @@ def test_partial_matching0():
         FROM A a
         LEFT JOIN B b ON a.id = b.cid
         WHERE
-        b.cl1 IN ('s1', 's2') OR b.cl1 = 's3 '
+        b.cl1 IN ('s1', 's2') OR b.cl1 = 's3'
         '''
     rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
     rules = [get_rule(k) for k in rule_keys]

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1094,7 +1094,7 @@ def test_partial_matching_base_case1():
         WHERE
         b.cl1 IN ('s1', 's2')
         '''
-    rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
+    rule_keys = ['combine_or_to_in']
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
@@ -1114,7 +1114,7 @@ def test_partial_matching_base_case2():
         WHERE
         b.cl1 IN ('s3', ('s1', 's2'))
         '''
-    rule_keys = ['merge_or_comparison_with_in_condition']
+    rule_keys = ['merge_or_to_in']
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
@@ -1135,7 +1135,7 @@ def test_partial_matching0():
         WHERE
         b.cl1 IN ('s1', 's2') OR b.cl1 = 's3'
         '''
-    rule_keys = ['multiple_equality_comparisons_with_or_to_same_element']
+    rule_keys = ['combine_or_to_in']
     rules = [get_rule(k) for k in rule_keys]
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))


### PR DESCRIPTION
## Overview
<img width="1111" alt="404456666-111576b4-26ad-4b04-ad99-711b49d2ca38" src="https://github.com/user-attachments/assets/1adb06d4-b4c2-448c-a97c-ab13a2c15a2e" />

This PR handles the common cases on partial matching for logical operators, e.g. `AND, OR, etc`. 

## Changes Made
- Modified rewrite logic, especially `match_node`, `match_dict`, and `match_list` to support partial matching.
- Modified replace logic within `replace` method to support partial matching.

## Testing
- Created 4 new test cases for partial matching.
- Passed all existing test cases defined under `test` 