### PR TITLE
Fix Issue with Select Clause Getting Dropped

### DIFF
--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -646,7 +646,8 @@ class QueryRewriter:
         if QueryRewriter.is_dict(query):       
             memo_key = ','.join(sorted(query.keys()))
             matching_memo_key = None
-            
+
+            # Only do merging if this memo_key hasn't been processed yet
             # Try exact match
             if memo_key in memo.keys() and memo_key not in memo['_merged_keys']:
                 matching_memo_key = memo_key

--- a/data/rules.py
+++ b/data/rules.py
@@ -268,6 +268,17 @@ SELECT <x3>.<x6>
     },
 
     {
+        'id': 70,
+        'key': 'remove_where_true',
+        'name': 'Remove Where True',
+        'pattern': 'FROM <x1> WHERE <x2> > <x2> - 2',
+        'constraints': '',
+        'rewrite': 'FROM <x1>',
+        'actions': '',
+        'database': 'postgresql'
+    },
+
+    {
         'id': 8090,
         'key': 'test_rule_wetune_90',
         'name': 'Test Rule Wetune 90',

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1164,6 +1164,23 @@ def test_partial_matching4():
     assert format(parse(q1)) == format(parse(_q1))
 
 
+def test_remove_where_true():
+    q0 = '''
+        SELECT *
+        FROM Emp
+        WHERE age > age - 2;
+        '''
+    q1 = '''
+        SELECT *
+        FROM emp
+        '''
+
+    rule_keys = ['remove_where_true']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
 # TODO - TBI
 # 
 def test_rewrite_postgresql():

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1172,7 +1172,7 @@ def test_remove_where_true():
         '''
     q1 = '''
         SELECT *
-        FROM emp
+        FROM Emp
         '''
 
     rule_keys = ['remove_where_true']


### PR DESCRIPTION
### Changes Made:
- Added subset matching logic in `replace()` to correctly match query and memo keys when query keys are a subset of memo keys.
- This prevents clauses from potentially getting dropped unintentionally
- Example: Query after rewrite `{'from': 'V001'`} will now match with memo key `'from,where'`

### Testing:
- Created test case `test_remove_where_true` to ensure that the `SELECT` clause is preserved 
- Pass all existing tests under `test`