### PR TITLE
Fix match_list

### DIFF
--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -403,6 +403,8 @@ class QueryRewriter:
             return True
         if len(query_node) == 0 and len(rule_node) == 0:
             return True
+        if query_node == rule_node:
+            return True
 
         # corner case
         # 

--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -403,8 +403,7 @@ class QueryRewriter:
             return True
         if len(query_node) == 0 and len(rule_node) == 0:
             return True
-        if query_node == rule_node:
-            return True
+
 
         # corner case
         # 
@@ -431,6 +430,10 @@ class QueryRewriter:
                 return False
             else:
                 remaining_in_query.remove(constant)
+        
+        # If both remaining lists are empty, all constants matched and should return True
+        if len(remaining_in_rule) == 0 and len(remaining_in_query) == 0:
+            return True
         
         # - Part-2) The remaining dicts, Vars and VarList in rule_node should PARTIALLY
         #             match the remaining constants and dicts in query_node 

--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -404,7 +404,6 @@ class QueryRewriter:
         if len(query_node) == 0 and len(rule_node) == 0:
             return True
 
-
         # corner case
         # 
         if len(rule_node) == 1 and QueryRewriter.is_varList(rule_node[0]):

--- a/data/rules.py
+++ b/data/rules.py
@@ -452,7 +452,17 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
       "rewrite": "SELECT DISTINCT <x17>, <x16>, <x15>, <x14> FROM <x1>, <x2> WHERE <x1>.<x8> = <x2>.<x4> AND <<y2>>",
       'actions': '',
       'database': 'mysql'
-    }
+    },
+    {
+      "id": 2263,
+      'key': 'and_on_true',
+      'name': 'where 1 and 1',
+      "pattern": "FROM <x1> WHERE 1 AND 1",
+      'constraints': '',
+      "rewrite": "FROM <x1>",
+      'actions': '',
+      'database': 'mysql'
+    },
 ]
 
 # fetch one rule by key (json attributes are in json)

--- a/data/rules.py
+++ b/data/rules.py
@@ -467,8 +467,18 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
     {
       "id": 2263,
       'key': 'and_on_true',
-      'name': 'where 1 and 1',
+      'name': 'where TRUE and TRUE',
       "pattern": "FROM <x1> WHERE 1 AND 1",
+      'constraints': '',
+      "rewrite": "FROM <x1>",
+      'actions': '',
+      'database': 'mysql'
+    },
+    {
+      "id": 2264,
+      'key': 'multiple_and_on_true',
+      'name': 'where TRUE and TRUE in set representation',
+      "pattern": "FROM <x1> WHERE <<y>>",
       'constraints': '',
       "rewrite": "FROM <x1>",
       'actions': '',

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1164,6 +1164,24 @@ def test_partial_matching4():
     assert format(parse(q1)) == format(parse(_q1))
 
 
+def test_and_on_true():
+    q0 = '''
+        SELECT people.name
+        FROM people
+        WHERE 1 AND 1
+        '''
+    q1 = '''
+        SELECT people.name
+        FROM people
+        '''
+    rule_keys = ['and_on_true']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    print(_q1)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
+
 # TODO - TBI
 # 
 def test_rewrite_postgresql():

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1181,6 +1181,23 @@ def test_and_on_true():
     assert format(parse(q1)) == format(parse(_q1))
 
 
+def test_multipleand_on_true():
+    q0 = '''
+        SELECT name
+        FROM people
+        WHERE 1 = 1 AND 2 = 2
+        '''
+    q1 = '''
+        SELECT name
+        FROM people
+        '''
+    rule_keys = ['multiple_and_on_true']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    print(_q1)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
 def test_rewrite_rule_remove_where_true():
     q0 = '''
         SELECT *

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1164,7 +1164,7 @@ def test_partial_matching4():
     assert format(parse(q1)) == format(parse(_q1))
 
 
-def test_and_on_true():
+def test_rewrite_and_on_true():
     q0 = '''
         SELECT people.name
         FROM people
@@ -1181,7 +1181,7 @@ def test_and_on_true():
     assert format(parse(q1)) == format(parse(_q1))
 
 
-def test_multipleand_on_true():
+def test_rewrite_multiple_and_on_true():
     q0 = '''
         SELECT name
         FROM people


### PR DESCRIPTION
# Overview
This PR fixed the issue of the `match_list` method incorrectly returning `False` for identical lists containing only constants, such as:
- `WHERE 1 AND 1`  -> `{ 'AND' : [1, 1] }` - > `[1, 1]`
- `WHERE 1=1 AND 2=2` -> `{ '=': [1, 1] },  { '=': [2, 2] }` -> `[1, 1], [2, 2]`

Big thanks to @colinthebomb1 for fixing the `replace` method in the previous PR, I relied on that fix as part of this update.

# Root Cause
After successfully matching all constants, when both `remaining_in_rule` and `remaining_in_query` lists were empty, the method would skip the following nested loops and return `False` at the end, even though the match was actually successful and should return `True`.
# Changes
- Add early return check before entering the loop in `match_list` method.
- Add 2 new test cases, all test cases passed.

# Issues
Closes #58
Closes #57 