### PR TITLE
Fix Rule Generator Variable Mismatch

### DIFF
--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -2502,6 +2502,8 @@ class RuleGenerator:
         # 1. Get candidate subtrees from rule
         #
         subtrees = RuleGenerator.subtrees(rule['pattern_json'], rule['rewrite_json'])
+        print(subtrees)
+        print(rule['pattern_json'], rule['rewrite_json'])
 
         # 2. Make all candidate subtrees variables, and generate a new rule
         #
@@ -2519,9 +2521,18 @@ class RuleGenerator:
         new_rule_rewrite_json = json.loads(new_rule['rewrite_json'])
 
         for subtree in subtrees:
-            # Find a variable name for the given subtree
-            #
-            new_rule_mapping, newVarInternal = RuleGenerator.findNextVarInternal(new_rule_mapping)
+            # for single-key subtrees, use the inner variable instead of creating new one
+            if len(subtree) == 1:
+                inner_value = list(subtree.values())[0]
+                if QueryRewriter.is_var(inner_value):
+                    # use the existing inner variable
+                    newVarInternal = inner_value
+                else:
+                    # find a variable name for the given subtree
+                    new_rule_mapping, newVarInternal = RuleGenerator.findNextVarInternal(new_rule_mapping)
+            else:
+                # find a variable name for the given subtree
+                new_rule_mapping, newVarInternal = RuleGenerator.findNextVarInternal(new_rule_mapping)
 
             # Replace given subtree into newVarInternal in new rule
             #

--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -1226,8 +1226,6 @@ class RuleGenerator:
         # find the common subtrees in pattern and rewrite
         #
         ans = []
-        print(patternSubtrees)
-        print(rewriteSubtrees)
         while len(patternSubtrees) > 0:
             patternSubtree = patternSubtrees.pop()
             for rewriteSubtree in rewriteSubtrees:
@@ -1242,7 +1240,6 @@ class RuleGenerator:
     #
     @staticmethod
     def sameSubtree(left: dict, right: dict) -> bool:
-        print(left, right)
         for key, leftValue in left.items():
             if key not in right:
                 return False
@@ -1440,9 +1437,7 @@ class RuleGenerator:
                     if len(path) > 0 and path[-1] == 'select' and 'value'in astJson.keys():
                         return {'value': var}
                     # otherwise
-                    # check for boolean flags ex. {'distinct': True}
-                    else:
-                        return var
+                    return var
             # otherwise
             #
             else:
@@ -1451,7 +1446,6 @@ class RuleGenerator:
                 for key, value in astJson.items():
                     # note: key can not be subtree, only traverse each value
                     astJson[key] = RuleGenerator.replaceSubtreesOfASTJson(value, path + [key], subtree, var)
-                                
                 return astJson
 
         # Case-2: list
@@ -2533,11 +2527,8 @@ class RuleGenerator:
             #
             new_rule_pattern_json = RuleGenerator.replaceSubtreesOfASTJson(new_rule_pattern_json, [], subtree, newVarInternal)
             new_rule_rewrite_json = RuleGenerator.replaceSubtreesOfASTJson(new_rule_rewrite_json, [], subtree, newVarInternal)
-
-            print(new_rule_pattern_json)
-            print(new_rule_rewrite_json)
         
-        # Only accept the rule if it generalizes both pattern and rewrite 
+        # Only accept the rule if it generalizes both pattern and rewrite
         #
         if (new_rule['pattern_json'] != json.dumps(new_rule_pattern_json)) and (new_rule['rewrite_json'] != json.dumps(new_rule_rewrite_json)):
             new_rule['mapping'] = json.dumps(new_rule_mapping)
@@ -3673,4 +3664,5 @@ class RuleGenerator:
                 return False, "Error in second query, current Scope is " + ScopeInfo[patternScope] +  " if that is not intended check spelling at index 0. Expecting "  + var.group(1).strip() + " found " + var.group(2).strip(), errorindex2
     
             return False, e.message, -1
+
 

--- a/tests/test_rule_generator.py
+++ b/tests/test_rule_generator.py
@@ -2205,8 +2205,8 @@ def test_generate_general_rule_19():
     assert type(rule) is dict
 
     q0_rule, q1_rule = unify_variable_names(rule['pattern'], rule['rewrite'])
-    assert q0_rule == "SELECT <x1>"
-    assert q1_rule == "SELECT DISTINCT <x1>"
+    assert q0_rule == "MAX(<x1>)"
+    assert q1_rule == "MAX(DISTINCT <x1>)"
 
 # def test_suggest_rules_bf_1():
 #     examples = [

--- a/tests/test_rule_generator.py
+++ b/tests/test_rule_generator.py
@@ -2205,8 +2205,8 @@ def test_generate_general_rule_19():
     assert type(rule) is dict
 
     q0_rule, q1_rule = unify_variable_names(rule['pattern'], rule['rewrite'])
-    assert q0_rule == "<x1>"
-    assert q1_rule == "DISTINCT <x1>"
+    assert q0_rule == "SELECT <x1>"
+    assert q1_rule == "SELECT DISTINCT <x1>"
 
 # def test_suggest_rules_bf_1():
 #     examples = [

--- a/tests/test_rule_generator.py
+++ b/tests/test_rule_generator.py
@@ -2197,6 +2197,17 @@ def test_generate_general_rule_18():
     assert q0_rule== "SELECT <x1>.<x2> FROM <x1> WHERE <x1>.<x2> > <x3> AND <x1>.<x2> <= <x3>"
     assert q1_rule == "SELECT <x2> FROM <x1> WHERE False"
 
+def test_generate_general_rule_19():
+    q0 = "SELECT max(id) FROM Emp"
+    q1 = "SELECT max(DISTINCT id) FROM Emp"
+
+    rule = RuleGenerator.generate_general_rule(q0, q1)
+    assert type(rule) is dict
+
+    q0_rule, q1_rule = unify_variable_names(rule['pattern'], rule['rewrite'])
+    assert q0_rule == "<x1>"
+    assert q1_rule == "DISTINCT <x1>"
+
 # def test_suggest_rules_bf_1():
 #     examples = [
 #         {


### PR DESCRIPTION
## Overview:
This PR fixes an issue where The MAX clause would get generalized out of the pattern but not rewrite, leading to a variable mismatch for the following example:
-  `SELECT max(id) FROM Emp` -> `<x3>`
-  `SELECT max(DISTINCT id) FROM Emp` -> `MAX(DISTINCT <x2>)`

### Changes Made:
- Added check in `variablize_all_subtrees()` to only change a rule if a generalization is made to both pattern and rewrite.
- This prevents incorrect partial generalizations

### Testing:
- Created test case `test_generate_general_rule_19()` to ensure that the `MAX` clause is not mistakenly generalized out
- Pass all existing tests under `test`

### Issues:
- Closes #61 