### PR TITLE
Fix partial matching to preserve unmatched clauses

### DIFF
--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -630,7 +630,7 @@ class QueryRewriter:
         if query is memo['rule']:
             # replace query by rule's rewrite
             # 
-            
+
             # Partial Matching Case: where memo['rule'] only contains the partial matched node
             # after rewrite, we need to manually put it back to the original operator clause
             if QueryRewriter.is_dict(query):

--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -628,7 +628,9 @@ class QueryRewriter:
         # 1st case, find the matched part by the rule
         # 
         if query is memo['rule']:
-
+            # replace query by rule's rewrite
+            # 
+            
             # Partial Matching Case: where memo['rule'] only contains the partial matched node
             # after rewrite, we need to manually put it back to the original operator clause
             if QueryRewriter.is_dict(query):
@@ -642,7 +644,7 @@ class QueryRewriter:
             # is overwritten by rewrite  
             all_keys = QueryRewriter.get_all_keys(original_query)
             ops_to_remove = set()
-            
+
             if QueryRewriter.is_dict(query):
                 for op in memo.keys():                    
                     if op not in all_keys:

--- a/data/rules.py
+++ b/data/rules.py
@@ -279,6 +279,28 @@ SELECT <x3>.<x6>
     },
 
     {
+        'id': 80,
+        'key': 'nested_clause_to_inner_join',
+        'name': 'Nested Clause to INNER JOIN',
+        'pattern': 'SELECT <x3> FROM <x1> WHERE <x4> IN (SELECT <x5> FROM <x2> WHERE <x6> = <x7>)',
+        'constraints': '',
+        'rewrite': 'SELECT <x1>.<x3> FROM <x1> INNER JOIN <x2> ON <x2>.<x5> = <x1>.<x4> WHERE <x2>.<x6> = <x7>',
+        'actions': '',
+        'database': 'postgresql'
+    },
+
+        {
+        'id': 81,
+        'key': 'contradiction_gt_lte',
+        'name': 'Contradiction GT LTE',
+        'pattern': 'SELECT <<x2>> FROM <<x1>> WHERE <x4> > <x3> AND <x4> <= <x3>',
+        'constraints': '',
+        'rewrite': 'SELECT <<x2>> FROM <<x1>> WHERE False',
+        'actions': '',
+        'database': 'postgresql'
+    },
+
+    {
         'id': 8090,
         'key': 'test_rule_wetune_90',
         'name': 'Test Rule Wetune 90',


### PR DESCRIPTION
## Overview:
This PR fixes an issue where unmatched clauses from partial matching would get dropped and not included in the final rewrite

### Changes Made:
- Modified replace() to correctly add back remaining clauses from logical operators.
- These clauses must be added back before the operator attached to remaining clauses is potentially overwritten by the rewrite rule.

### Testing:
- Created test case `test_partial_keeps_remaining_AND()` to ensure that the unmatched `AND` clauses aren't dropped
- Created test case `test_partial_keeps_remaining_OR()` to ensure that the unmatched `OR` clauses aren't dropped
- Pass all existing tests under `test`

### Issues:
- Closes #60 


Major thank you to @HazelYuAhiru for the help on this PR