### PR TITLE
[Improvement] priority issue between full match and partial match

### DIFF
--- a/data/rules.py
+++ b/data/rules.py
@@ -506,6 +506,16 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
       'actions': '',
       'database': 'mysql'
     },
+    {
+      "id": 2265,
+      'key': 'multiple_or_to_union',
+      'name': 'multiple or to union',
+      "pattern": "SELECT <<y11>> FROM <x1> WHERE <x1>.<x4> IN (SELECT <<y10>> FROM <x2> WHERE <<y6>>) OR <x1>.<x4> IN (SELECT <<y9>> FROM <x3> WHERE <<y4>>)",
+      'constraints': '',
+      "rewrite": "SELECT <<y11>> FROM <x1> WHERE <x1>.<x4> IN (SELECT <<y10>> FROM <x2> WHERE <<y6>>) UNION SELECT <<y11>> FROM <x1> WHERE <x1>.<x4> IN (SELECT <<y9>> FROM <x3> WHERE <<y4>>)",
+      'actions': '',
+      'database': 'mysql'
+    }
 ]
 
 # fetch one rule by key (json attributes are in json)

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1264,6 +1264,26 @@ def test_rewrite_rule_remove_where_true():
     assert format(parse(q1)) == format(parse(_q1))
 
 
+def test_matching_order():
+    q0 = '''
+    SELECT entities.data FROM entities WHERE 
+    entities._id IN (SELECT index_users_email._id FROM index_users_email WHERE index_users_email.key = 'test')
+    OR 
+    entities._id in (SELECT index_users_profile_name._id FROM index_users_profile_name WHERE index_users_profile_name.key = 'test')
+    '''
+
+    q1 = '''
+    SELECT entities.data FROM entities INNER JOIN index_users_email ON index_users_email._id = entities._id
+    WHERE index_users_email.key = 'test'
+    UNION
+    SELECT entities.data FROM entities INNER JOIN index_users_profile_name ON index_users_profile_name._id = entities._id
+    WHERE index_users_profile_name.key = 'test'
+    '''
+    rule_keys = ['nested_clause_to_inner_join', 'multiple_or_to_union']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
 # TODO - TBI
 # 
 def test_rewrite_postgresql():


### PR DESCRIPTION
## Overview
This PR prioritizes fully matching rules over partially matched ones.

## Changes Made
- Implemented a two-pass logic in rewrite
- Added an `allow_partial_matching` flag to the matching logic
- Added a new test case based on the SqlRewriter Engine Evaluation spreadsheet

## Tests
All existing test cases passed.