### PR TITLE
Fix partial matching potentially causing failed rewrite

### DIFF
--- a/core/query_rewriter.py
+++ b/core/query_rewriter.py
@@ -108,12 +108,16 @@ class QueryRewriter:
                         break
             
             # apply the rule and found
-            if rule_applied is not None:
-                query_ast = QueryRewriter.take_actions(query_ast, rule_applied, memo_applied)
-                query_ast = QueryRewriter.replace(query_ast, rule_applied, memo_applied)
-                rewriting_path.append([rule_applied['id'], format(query_ast)])
-                if not cycle_found and iterate:
-                    new_query = True
+            try:
+                if rule_applied is not None:
+                    query_ast = QueryRewriter.take_actions(query_ast, rule_applied, memo_applied)
+                    query_ast = QueryRewriter.replace(query_ast, rule_applied, memo_applied)
+                    rewriting_path.append([rule_applied['id'], format(query_ast)])
+                    if not cycle_found and iterate:
+                        new_query = True
+            except:
+                print(f"Failed to rewrite with rule: {rule}")
+                continue
 
         return format(query_ast), rewriting_path
     

--- a/data/rules.py
+++ b/data/rules.py
@@ -289,7 +289,7 @@ SELECT <x3>.<x6>
         'database': 'postgresql'
     },
 
-        {
+    {
         'id': 81,
         'key': 'contradiction_gt_lte',
         'name': 'Contradiction GT LTE',
@@ -299,6 +299,27 @@ SELECT <x3>.<x6>
         'actions': '',
         'database': 'postgresql'
     },
+
+    {
+        'id': 90,
+        'key': 'subquery_to_joins',
+        'name': 'Subquery to Joins',
+        'pattern': '''FROM <x1> 
+                      WHERE <<x2>> 
+                      AND <x1>.<x3> 
+                      IN (SELECT <x4>.<x5> FROM <x4> WHERE <<x6>>) 
+                      AND <x1>.<x3> 
+                      IN (SELECT <x7>.<x5> FROM <x7> WHERE <<x8>>)''',
+        'constraints': '',
+        'rewrite': '''FROM <x1> 
+                      JOIN <x4> ON <x1>.<x3> = <x4>.<x5> 
+                      JOIN <x7> ON <x1>.<x3> = <x7>.<x5> 
+                      WHERE <<x2>> 
+                      AND <<x6>> 
+                      AND <<x8>>''',
+        'actions': '',
+        'database': 'postgresql'
+    }, 
 
     {
         'id': 8090,


### PR DESCRIPTION
## Overview:
This PR fixes an issue where partial matching could cause a failed rewrite with an error.

### Changes Made:
- Modified `rewrite()` to have a try except block when rewriting with a matched rule, allowing rules that cause errors to be passed over

### Testing:
- Created test case `test_rewrite_skips_failed_partial` to check that rule that previously generated error is skipped over.
- Created test case `test_generate_general_rule_20`
- Pass all existing tests under `test`