### PR TITLE
[Fix] Prevent Over Partial Matching

### DIFF
--- a/data/rules.py
+++ b/data/rules.py
@@ -468,6 +468,16 @@ SELECT t6.<x3>, MIN(MIN(<x1>.<x4>))
         'database': 'mysql'
     },
     {
+        'id': 2280,
+        'key': 'combine_3_or_to_in',
+        'name': 'combine multiple or to in',
+        'pattern': '<x> = <y> OR <x> = <z> OR <x> = <w>',
+        'constraints': '',
+        'rewrite': '<x> IN (<y>, <z>, <w>)',
+        'actions': '',
+        'database': 'mysql'
+    },
+    {
         'id': 2259,
         'key': 'merge_or_to_in',
         'name': 'merge or to in',

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1381,6 +1381,19 @@ def test_full_matching():
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
 
+def test_over_partial_matching():
+    q0 = '''
+        SELECT * FROM table_name WHERE (table_name.title = 1 and table_name.grade = 2) OR (table_name.title = 2 and table_name.debt = 2 and table_name.grade = 3) OR (table_name.prog = 1 and table_name.title =1 and table_name.debt = 3)
+        '''
+    q1 = '''
+        SELECT * FROM table_name WHERE (table_name.title = 1 and table_name.grade = 2) OR (table_name.title = 2 and table_name.debt = 2 and table_name.grade = 3) OR (table_name.prog = 1 and table_name.title =1 and table_name.debt = 3)
+        '''
+    rule_keys = ['combine_3_or_to_in']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
+
 # TODO - TBI
 # 
 def test_rewrite_postgresql():


### PR DESCRIPTION
## Overview
This PR fixes an issue where the original partial matching logic skipped internal tree layers during a partial match, as shown in the screenshot below, which was not the expected behavior. 
<img width="1096" height="555" alt="Screen Shot 2025-08-08 at 2 10 57 PM" src="https://github.com/user-attachments/assets/6dda5951-9a2e-48a6-ba9b-20010717967b" />

Partial matching means the entire rule AST can match against any subtree of the query AST. However, once the rule matches the root node of some subtree, the rule must then fully match the entire subtree from that point downward.

## Changes Made

- Added enum `MatchingMode` to set the matching mode in the current tree matching loop.
- Updated matching logic to prevent the case of "partial matching inside a partial match."
