### PR TITLE
Prevents infinite loop in rule generalization

### DIFF
--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -2714,15 +2714,14 @@ class RuleGenerator:
         #   recursively until no more differences
         #
         generalRule = seedRule
-        preRuleFingerprint = RuleGenerator.fingerPrint(generalRule)
-        diff = True
-        while diff:
+        visited_fingerprints = set()
+        ruleFingerprint = RuleGenerator.fingerPrint(generalRule)
+
+        while ruleFingerprint not in visited_fingerprints:
+            visited_fingerprints.add(ruleFingerprint)
             for generalization in RuleGenerator.RuleGeneralizations.keys():
                 generalRule = getattr(RuleGenerator, generalization)(generalRule)
-            newRuleFingerprint = RuleGenerator.fingerPrint(generalRule)
-            if newRuleFingerprint == preRuleFingerprint:
-                diff = False
-            preRuleFingerprint = newRuleFingerprint
+            ruleFingerprint = RuleGenerator.fingerPrint(generalRule)
         
         return generalRule
 


### PR DESCRIPTION
## Overview:
This PR prevents infinite loops in the rule generator. Previously, the code only checked if the fingerprint matched the previous rules' fingerprint, but this wouldn't stop infinite loops of larger size. ex.  Rule A -> Rule B -> Rule C -> Rule A

### Testing:
- Pass all existing tests under `test`