### PR TITLE
[FIX]  Infinite Loop in Variablization of Subtrees

### DIFF
--- a/core/rule_generator.py
+++ b/core/rule_generator.py
@@ -2563,6 +2563,11 @@ class RuleGenerator:
         new_rule_rewrite_json = json.loads(new_rule['rewrite_json'])
 
         for subtree in subtrees:
+            # Prevents already variablized subtrees from being variablized again in an infinite loop
+            # ex. {"value": "V22"} should not be variablized again
+            if len(subtree) == 1 and 'value' in subtree and QueryRewriter.is_var(subtree['value']):
+                continue
+            
             # Find a variable name for the given subtree
             #
             new_rule_mapping, newVarInternal = RuleGenerator.findNextVarInternal(new_rule_mapping)

--- a/data/rules.py
+++ b/data/rules.py
@@ -322,6 +322,17 @@ SELECT <x3>.<x6>
     }, 
 
     {
+        'id': 91,
+        'key': 'aggregation_to_filtered_subquery',
+        'name': 'Aggregation to Filtered Subquery',
+        'pattern': '''SELECT <x2>.<x9>, DATE(<x2>.<x3>), CASE WHEN SUM(CASE WHEN <x2>.<x4> = <x5> THEN <x5> ELSE <x6> END) >= <x5> THEN <x5> ELSE <x6> END FROM <x8> AS <x2> GROUP BY <<x7>>, DATE(<x2>.<x3>)''',
+        'constraints': '',
+        'rewrite': '''SELECT <x2>.<x9>, <x2>.<x3> FROM (SELECT <x9>, DATE(<x3>) FROM <x8> WHERE <x4> = <x5>) AS <x2> GROUP BY <<x7>>, <x2>.<x3>''',
+        'actions': '',
+        'database': 'postgresql'
+    }, 
+
+    {
         'id': 8090,
         'key': 'test_rule_wetune_90',
         'name': 'Test Rule Wetune 90',

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1393,6 +1393,40 @@ def test_over_partial_matching():
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
 
+def test_rewrite_test():
+    q0 = '''
+SELECT 
+    t1.CPF,
+    DATE(t1.data) AS data,
+    CASE WHEN SUM(CASE WHEN t1.login_ok = true
+                       THEN 1
+                       ELSE 0
+                  END) >= 1
+         THEN true
+         ELSE false
+    END
+FROM db_risco.site_rn_login AS t1
+GROUP BY t1.CPF, DATE(t1.data)
+        '''
+    q1 = '''
+SELECT
+    t1.CPF,
+    t1.data    
+FROM (
+    SELECT 
+        CPF, 
+        DATE(data)
+    FROM db_risco.site_rn_login
+    WHERE login_ok = true
+) t1
+GROUP BY t1.CPF, t1.data
+        '''
+    
+    rule_keys = ['aggregation_to_filtered_subquery']
+    rules = [get_rule(k) for k in rule_keys]
+    _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
+    assert format(parse(q1)) == format(parse(_q1))
+
 
 # TODO - TBI
 # 

--- a/tests/test_query_rewriter.py
+++ b/tests/test_query_rewriter.py
@@ -1393,7 +1393,7 @@ def test_over_partial_matching():
     _q1, _rewrite_path = QueryRewriter.rewrite(q0, rules)
     assert format(parse(q1)) == format(parse(_q1))
 
-def test_rewrite_test():
+def test_rewrite_aggregation_to_subquery():
     q0 = '''
 SELECT 
     t1.CPF,


### PR DESCRIPTION
## Overview:
This PR fixes an infinite loop in `variablize_subtrees()`, where an already variablized subtree like  {"value": "V22"} would be variablized again in an infinite loop, ex. {"value": "V22"} -> {"value": "V27"} -> {"value": "V32"} etc.

### Testing:
- Pass all existing tests under `test`
- Added `test_generate_general_rule_22` and `test_rewrite_aggregation_to_subquery` 